### PR TITLE
Fixed robot tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,13 @@ before_install:
 install:
   - python bootstrap-buildout.py -c travis.cfg
   - bin/buildout -Nc travis.cfg
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - firefox -v
 script:
   - bin/code-analysis
-  - bin/test
+  - bin/test --all
 after_success:
   - bin/createcoverage
   - pip install coverage==3.7 coveralls

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/release/4.3.8/versions.cfg
+extends = http://dist.plone.org/release/4.3.11/versions.cfg
 extensions = mr.developer
 parts =
     instance
@@ -70,9 +70,7 @@ zc.buildout = 2.4.1
 zc.recipe.egg = 2.0.2
 flake8 = 2.5.4
 i18ndude = 3.4.0
-robotframework = 3.0
-robotframework-ride = 1.5
-robotframework-selenium2library = 1.7.4
-robotsuite = 1.7.0
-selenium = 2.53.1
-plone.app.locales = 4.3.9
+
+# Pin flake8-coding to avoid this issue:
+# https://github.com/tk0miya/flake8-coding/issues/10
+flake8-coding = 1.2.2

--- a/src/collective/calltoaction/tests/robot/test_overlay.robot
+++ b/src/collective/calltoaction/tests/robot/test_overlay.robot
@@ -74,7 +74,7 @@ I enter valid credentials
   Click Button  Log in
 
 I wait a short time
-  Sleep  1.5
+  Sleep  3
 
 I reload the page
   Reload Page

--- a/travis.cfg
+++ b/travis.cfg
@@ -13,6 +13,3 @@ eggs = createcoverage
 
 [versions]
 coverage = 3.7
-# Pin flake8-coding to avoid this issue:
-# https://github.com/tk0miya/flake8-coding/issues/10
-flake8-coding = 1.2.2


### PR DESCRIPTION
Wait longer before checking visibility, as the robot tests can be slower than expected.
Actually run them on Travis (with bin/test --all).
Use Plone 4.3.11.
Pin flake8-coding in buildout.cfg instead of travis.cfg.